### PR TITLE
Move CI actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/generate-check.yml
+++ b/.github/workflows/generate-check.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Open an issue when scheduled run finds broken links
         if: ${{ github.event_name != 'pull_request' && steps.lychee.outputs.exit_code != 0 }}
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: "Broken links found in README.md"
           content-filepath: ./lychee/out.md


### PR DESCRIPTION
## What

Every workflow run has been warning:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4
```

Harmless today — the runner shims it. But when GitHub drops that shim, **both workflows break simultaneously**, since each depends on `actions/checkout`. Two-line fix now, urgent fix later.

## What changed

I checked the declared runtime of every action at every available major tag rather than trusting the warning, and bumped each to the lowest major declaring `node24`:

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v4 = node20, v5+ = node24 |
| `actions/cache` | v4 | **v5** | v4 = node20, v5+ = node24 |
| `actions/setup-python` | v5 | **v6** | v5 = node20, v6+ = node24 |
| `peter-evans/create-issue-from-file` | v5 | **v6** | v5 = node20, v6 = node24 |
| `lycheeverse/lychee-action` | v2 | *unchanged* | composite action, no Node runtime |

## The warning was incomplete

It named only `checkout` and `cache` — because it came from the `link-check` job, which is the only place those two appear. `setup-python@v5` and `create-issue-from-file@v5` are **also** on node20 and would have been left behind by a fix that trusted the warning at face value. `setup-python` runs in `generate-check`; `create-issue-from-file` only runs on the weekly schedule when a link has rotted, so its warning would surface rarely and at the least convenient moment.

## Why lowest-major rather than latest

Latest majors are checkout v7, cache v6, setup-python v7. I deliberately went to v5/v5/v6 instead. This is a runtime fix — the goal is getting off node20, and every additional major crossed carries unrelated breaking-change risk for no benefit here. Happy to go to latest instead if you'd rather have the longer runway before the next deprecation.

## Verification

The runtimes above were read directly from each action's `action.yml` at each tag (shallow clone per tag), not inferred from release notes or search. CI on this PR is itself the test: if any bumped action misbehaves, `linkcheck` and `generate-check` go red.

One gap worth naming: `create-issue-from-file` only executes on the **scheduled** run when broken links are found, so this PR's CI does not exercise it. Its bump is verified only by the declared runtime, not by an actual run.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177NvFcduvDJbjNRqogQDz4)_